### PR TITLE
Allow for nested updates of array items

### DIFF
--- a/.changeset/new-pillows-wink.md
+++ b/.changeset/new-pillows-wink.md
@@ -2,4 +2,4 @@
 "@arcanejs/diff": minor
 ---
 
-Introduce splice diffing
+Introduce advanced array diffing + patching (splices and nested changes)

--- a/packages/diff/src/diff.test.ts
+++ b/packages/diff/src/diff.test.ts
@@ -61,10 +61,8 @@ describe("diff", () => {
 
     it("should diff identify single item to replace", () => {
       expect(diffJson([1, 2, 3], [1, 2, 4])).toEqual({
-        type: "splice",
-        start: 2,
-        count: 1,
-        items: [4],
+        type: "modified-a",
+        changes: [{ i: 2, diff: { type: "value", before: 3, after: 4 } }],
       });
     });
 
@@ -125,10 +123,10 @@ describe("diff", () => {
     });
 
     it("should identify multiple items to replace", () => {
-      expect(diffJson([1, 2, 3, 6, 7], [1, 2, 4, 5, 7])).toEqual({
+      expect(diffJson([1, 2, 3, 6, 6.5, 7], [1, 2, 4, 5, 7])).toEqual({
         type: "splice",
         start: 2,
-        count: 2,
+        count: 3,
         items: [4, 5],
       });
     });
@@ -155,7 +153,7 @@ describe("diff", () => {
         describe(`value: ${JSON.stringify(v)}`, () => {
           it("deletions should be output", () => {
             expect(diffJson({ a: 1, b: v, c: 3 }, { a: 1, c: 3 })).toEqual({
-              type: "modified",
+              type: "modified-o",
               deletions: { b: v },
             });
           });
@@ -164,14 +162,14 @@ describe("diff", () => {
             expect(
               diffJson({ a: 1, b: v, c: 3 }, { a: 1, b: undefined, c: 3 }),
             ).toEqual({
-              type: "modified",
+              type: "modified-o",
               deletions: { b: v },
             });
           });
 
           it("additions should be output", () => {
             expect(diffJson({ a: 1, c: 3 }, { a: 1, b: v, c: 3 })).toEqual({
-              type: "modified",
+              type: "modified-o",
               additions: { b: v },
             });
           });
@@ -180,7 +178,7 @@ describe("diff", () => {
             expect(
               diffJson({ a: 1, b: undefined, c: 3 }, { a: 1, b: v, c: 3 }),
             ).toEqual({
-              type: "modified",
+              type: "modified-o",
               additions: { b: v },
             });
           });
@@ -190,14 +188,14 @@ describe("diff", () => {
 
     it("changes should be output", () => {
       expect(diffJson({ a: 1, b: 2, c: 3 }, { a: 1, b: 4, c: 3 })).toEqual({
-        type: "modified",
+        type: "modified-o",
         changes: { b: { type: "value", before: 2, after: 4 } },
       });
     });
 
     it("deletions, additions, and changes should be output", () => {
       expect(diffJson({ a: 1, b: 2, c: 3 }, { a: 1, c: 4, d: null })).toEqual({
-        type: "modified",
+        type: "modified-o",
         additions: { d: null },
         deletions: { b: 2 },
         changes: { c: { type: "value", before: 3, after: 4 } },
@@ -222,17 +220,15 @@ describe("diff", () => {
           { a: 1, b: { c: 2, d: 4 }, e: [4, 5, 7] },
         ),
       ).toEqual({
-        type: "modified",
+        type: "modified-o",
         changes: {
           b: {
-            type: "modified",
+            type: "modified-o",
             changes: { d: { type: "value", before: 3, after: 4 } },
           },
           e: {
-            type: "splice",
-            start: 2,
-            count: 1,
-            items: [7],
+            type: "modified-a",
+            changes: [{ i: 2, diff: { type: "value", before: 6, after: 7 } }],
           },
         },
       });

--- a/packages/diff/src/diff.ts
+++ b/packages/diff/src/diff.ts
@@ -12,10 +12,19 @@ export type NestedDiff<V extends JSONValue> =
   | (V extends JSONArray
       ? { type: "splice"; start: number; count: number; items: V }
       : never)
+  | (V extends JSONArray
+      ? {
+          type: "modified-a";
+          changes: Array<{
+            i: number;
+            diff: PossibleRecursiveDiff<V[number]>;
+          }>;
+        }
+      : never)
   // Objects may return `modified`
   | (V extends JSONObject
       ? {
-          type: "modified";
+          type: "modified-o";
           additions?: { [K in keyof V]: V[K] };
           deletions?: { [K in keyof V]: V[K] };
           changes?: { [K in keyof V]: PossibleRecursiveDiff<V[K]> };
@@ -40,38 +49,53 @@ export const diffJson = <V extends JSONValue>(
     throw new Error("Types don't match, unable to diff");
   }
   if (Array.isArray(a) && Array.isArray(b)) {
-    // Find earliest and latest non-matching items
+    // If arrays are same length, do a pairwise comparison of each item,
+    // otherwise perform a splice comparison
 
-    // Find start index of difference
-    let start = 0;
-    while (
-      start < a.length &&
-      start < b.length &&
-      diffJson(a[start], b[start]).type === "match"
-    ) {
-      start++;
+    if (a.length === b.length) {
+      const changes: Array<{ i: number; diff: NestedDiff<JSONValue> }> = [];
+      for (let i = 0; i < a.length; i++) {
+        const d = diffJson(a[i], b[i]);
+        if (d.type !== "match") {
+          changes.push({ i, diff: d });
+        }
+      }
+
+      if (changes.length === 0) {
+        return { type: "match" };
+      }
+
+      return { type: "modified-a", changes } as Diff<V>;
+    } else {
+      // Find earliest and latest non-matching items
+
+      // Find start index of difference
+      let start = 0;
+      while (
+        start < a.length &&
+        start < b.length &&
+        diffJson(a[start], b[start]).type === "match"
+      ) {
+        start++;
+      }
+
+      // Find end index of difference
+      let endIndexA = a.length - 1;
+      let endIndexB = b.length - 1;
+      while (
+        endIndexA >= start &&
+        endIndexB >= start &&
+        diffJson(a[endIndexA], b[endIndexB]).type === "match"
+      ) {
+        endIndexA--;
+        endIndexB--;
+      }
+
+      const count = endIndexA - start + 1;
+      const items = b.slice(start, endIndexB + 1);
+
+      return { type: "splice", start, count, items } as Diff<V>;
     }
-
-    if (start === a.length && start === b.length) {
-      return { type: "match" };
-    }
-
-    // Find end index of difference
-    let endIndexA = a.length - 1;
-    let endIndexB = b.length - 1;
-    while (
-      endIndexA >= start &&
-      endIndexB >= start &&
-      diffJson(a[endIndexA], b[endIndexB]).type === "match"
-    ) {
-      endIndexA--;
-      endIndexB--;
-    }
-
-    const count = endIndexA - start + 1;
-    const items = b.slice(start, endIndexB + 1);
-
-    return { type: "splice", start, count, items } as Diff<V>;
   }
   if (a === null || b === null) {
     return { type: "value", before: a, after: b } as Diff<V>;
@@ -101,7 +125,7 @@ export const diffJson = <V extends JSONValue>(
       }
     }
     const result = {
-      type: "modified",
+      type: "modified-o",
       ...(Object.keys(changes).length === 0 ? {} : { changes }),
       ...(Object.keys(additions).length === 0 ? {} : { additions }),
       ...(Object.keys(deletions).length === 0 ? {} : { deletions }),

--- a/packages/diff/src/patch.test.ts
+++ b/packages/diff/src/patch.test.ts
@@ -34,6 +34,19 @@ describe("patchJson", () => {
       expect(result?.[1]).toBe(a[1]);
       expect(result?.[4]).toBe(a[3]);
     });
+
+    it("should update nested values minimally", () => {
+      const a = [[1], [2], { a: [5], b: [6] }, [6]];
+      const b = [[1], [2], { a: [5] }, [6]];
+      const result = patchJson(a, diffJson(a, b));
+      expect(result).toEqual(b);
+
+      // Unchanged values should be exactly the same
+      expect(result?.[0]).toBe(a[0]);
+      expect(result?.[1]).toBe(a[1]);
+      expect(result?.[3]).toBe(a[3]);
+      expect((result?.[2] as any)?.a).toBe((a[2] as any)?.a);
+    });
   });
 
   describe("object changes should be reflected", () => {

--- a/packages/diff/src/patch.ts
+++ b/packages/diff/src/patch.ts
@@ -21,11 +21,22 @@ export const patchJson = <V extends JSONValue>(
     return result as V;
   }
 
-  if (Array.isArray(old)) {
-    throw new Error("Advanced array diffs not supported");
+  if (diff.type === "modified-a") {
+    if (!Array.isArray(old)) {
+      throw new Error("Cannot apply changes diff to non-array value");
+    }
+    const result = [...old];
+    for (const { i, diff: d } of diff.changes) {
+      result[i] = patchJson(old[i], d);
+    }
+    return result as V;
   }
 
-  if (diff.type === "modified") {
+  if (Array.isArray(old)) {
+    throw new Error("Unexpected array type");
+  }
+
+  if (diff.type === "modified-o") {
     if (typeof old !== "object" || old === null) {
       throw new Error("Cannot apply modified diff to non-object value");
     }


### PR DESCRIPTION
When array sizes match, instead of performing slice() operations when values differ, pairwise-compare each item in the arrays, and provide diffs for the individual items that have changed, which can then be recursively applied.