### PR TITLE
Export sourcemaps for library types

### DIFF
--- a/packages/diff/package.json
+++ b/packages/diff/package.json
@@ -39,7 +39,7 @@
   },
   "scripts": {
     "lint": "eslint . --max-warnings 0",
-    "build": "tsup",
+    "build": "tsup && tsc --emitDeclarationOnly --declaration",
     "dev": "tsup --watch",
     "test": "jest",
     "test:watch": "jest --watch"

--- a/packages/diff/tsconfig.json
+++ b/packages/diff/tsconfig.json
@@ -4,5 +4,5 @@
     "outDir": "dist"
   },
   "include": ["src"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist", "src/diff-type-checks.ts"],
 }

--- a/packages/diff/tsup.config.ts
+++ b/packages/diff/tsup.config.ts
@@ -3,5 +3,4 @@ import { defineConfig } from "tsup";
 export default defineConfig({
   entry: ["src/index.ts", "src/diff.ts", "src/patch.ts"],
   format: ["cjs", "esm"],
-  dts: true,
 });

--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -25,7 +25,7 @@
   },
   "scripts": {
     "lint": "eslint . --max-warnings 0",
-    "build": "tsup",
+    "build": "tsup && tsc --emitDeclarationOnly --declaration",
     "dev": "tsup --watch"
   },
   "devDependencies": {

--- a/packages/toolkit/src/index.ts
+++ b/packages/toolkit/src/index.ts
@@ -1,3 +1,7 @@
+import { diffJson } from "@arcanejs/diff/diff";
+
+console.log(diffJson);
+
 export class ToolkitServer {
   constructor() {
     console.log("ToolkitServer created");

--- a/packages/toolkit/tsup.config.ts
+++ b/packages/toolkit/tsup.config.ts
@@ -3,5 +3,4 @@ import { defineConfig } from "tsup";
 export default defineConfig({
   entry: ["src/index.ts"],
   format: ["cjs", "esm"],
-  dts: true,
 });


### PR DESCRIPTION
This will ease in development by allowing for the
typescript language server (and IDEs / editors) to have jump-to-definition for the original source
files for cross-package usage.

We should be able to avoid non-existent JS modules from being importable by virtue of having exports
specified in the package.json files.