### PR TITLE
Correct custom conditions

### DIFF
--- a/packages/diff/package.json
+++ b/packages/diff/package.json
@@ -22,16 +22,19 @@
   },
   "exports": {
     ".": {
+      "@arcanejs/source": "./src/index.ts",
       "import": "./dist/index.mjs",
       "require": "./dist/index.js",
       "types": "./dist/index.d.ts"
     },
     "./diff": {
+      "@arcanejs/source": "./src/diff.ts",
       "import": "./dist/diff.mjs",
       "require": "./dist/diff.js",
       "types": "./dist/diff.d.ts"
     },
     "./patch": {
+      "@arcanejs/source": "./src/patch.ts",
       "import": "./dist/patch.mjs",
       "require": "./dist/patch.js",
       "types": "./dist/patch.d.ts"

--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -18,6 +18,7 @@
   },
   "exports": {
     ".": {
+      "@arcanejs/source": "./src/index.ts",
       "import": "./dist/index.mjs",
       "require": "./dist/index.js",
       "types": "./dist/index.d.ts"


### PR DESCRIPTION
A follow-up commit in #32 accidentally removed the new conditions from the exports as other changes
were reverted. This corrects that.