### PR TITLE
Manually bump versions and release

### DIFF
--- a/.changeset/cool-bulldogs-wonder.md
+++ b/.changeset/cool-bulldogs-wonder.md
@@ -1,6 +1,0 @@
----
-'@arcanejs/react-toolkit': minor
-'@arcanejs/toolkit': minor
----
-
-Initial implementation

--- a/.github/workflows/release-and-publish.yaml
+++ b/.github/workflows/release-and-publish.yaml
@@ -36,7 +36,7 @@ jobs:
       - run: pnpm build
       - run: cp .npmrc.ci .npmrc
       - name: Run Changeset Workflow
-        uses: s0/changesets-action@647b61a3307a9fec0838dde37c1594888ad0ff5e # pinned-vA
+        uses: s0/changesets-action@50b4be2b5ce5350adb360d0ab15da3324e9976f5 # pinned-version of https://github.com/changesets/action/pull/391
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/examples/react/CHANGELOG.md
+++ b/examples/react/CHANGELOG.md
@@ -1,0 +1,9 @@
+# @arcanejs/examples-react
+
+## 0.0.1
+
+### Patch Changes
+
+- Updated dependencies [f54f4f5]
+  - @arcanejs/react-toolkit@0.1.0
+  - @arcanejs/toolkit@0.1.0

--- a/examples/react/package.json
+++ b/examples/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arcanejs/examples-react",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "private": true,
   "description": "Example app using toolkit",
   "scripts": {

--- a/packages/react-toolkit/CHANGELOG.md
+++ b/packages/react-toolkit/CHANGELOG.md
@@ -1,0 +1,12 @@
+# @arcanejs/react-toolkit
+
+## 0.1.0
+
+### Minor Changes
+
+- f54f4f5: Initial implementation
+
+### Patch Changes
+
+- Updated dependencies [f54f4f5]
+  - @arcanejs/toolkit@0.1.0

--- a/packages/react-toolkit/package.json
+++ b/packages/react-toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arcanejs/react-toolkit",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "private": false,
   "description": "Build web-accessible control interfaces for your long-running Node.js processes",
   "keywords": [

--- a/packages/toolkit/CHANGELOG.md
+++ b/packages/toolkit/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @arcanejs/toolkit
 
+## 0.1.0
+
+### Minor Changes
+
+- f54f4f5: Initial implementation
+
 ## 0.0.3
 
 ### Patch Changes

--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arcanejs/toolkit",
-  "version": "0.0.3",
+  "version": "0.1.0",
   "private": false,
   "description": "Build web-accessible control interfaces for your long-running Node.js processes",
   "keywords": [


### PR DESCRIPTION
Looks like changeset workflow is somewhat broken now, see: https://github.com/arcanejs/arcanejs/actions/runs/11418428423

Will manually update versions for now until the workflow is fixed.