### PR TITLE
Switch to uncontrolled inputs for TextInput

### DIFF
--- a/.changeset/brave-trees-lay.md
+++ b/.changeset/brave-trees-lay.md
@@ -1,0 +1,5 @@
+---
+'@arcanejs/toolkit-frontend': patch
+---
+
+Switch to uncontrolled input for TextInput to address cursor bugs

--- a/packages/toolkit-frontend/src/components/text-input.tsx
+++ b/packages/toolkit-frontend/src/components/text-input.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import React, { FC, useEffect } from 'react';
 import { styled } from 'styled-components';
 
 import * as proto from '@arcanejs/protocol';
@@ -14,10 +14,20 @@ interface Props {
 }
 
 const TextInput: FC<Props> = ({ className, info, sendMessage }) => {
+  const ref = React.useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    // Manually update value of text input if it doesn't match
+    if (ref.current && ref.current.value !== info.value) {
+      ref.current.value = info.value;
+    }
+  }, [info.value]);
+
   return (
     <input
       className={className}
-      value={info.value}
+      defaultValue={info.value}
+      ref={ref}
       onChange={(ev) =>
         sendMessage?.({
           type: 'component-message',


### PR DESCRIPTION
We were previously experiencing bugs where the cursor would jump to the end of the input when entering text, as the value field was set, this made it impossible to edit the middle of text. This change switches to using an uncontrolled input, and putting a manual check in place to determine whether the value needs to be updated using a reference to the input instead.