### PR TITLE
Improve the data API to allow for usage without provider

### DIFF
--- a/.changeset/mean-pens-leave.md
+++ b/.changeset/mean-pens-leave.md
@@ -1,0 +1,9 @@
+---
+'@arcanejs/react-toolkit': minor
+---
+
+**BREAKING:** Refactor the data file interface for easier direct use with hooks
+
+`createDataFileSpec` has been renamed to `createDataFileDefinition`
+`useDataFile` has been renamed to `useDataFileContext`,
+and `useDataFile` is now used to directly use the hooks without a provider.

--- a/examples/react/src/data-file.tsx
+++ b/examples/react/src/data-file.tsx
@@ -8,7 +8,10 @@ import {
   TextInput,
   Button,
 } from '@arcanejs/react-toolkit';
-import { createDataFileSpec, useDataFile } from '@arcanejs/react-toolkit/data';
+import {
+  createDataFileDefinition,
+  useDataFileContext,
+} from '@arcanejs/react-toolkit/data';
 import { z } from 'zod';
 import path from 'path';
 
@@ -21,14 +24,13 @@ toolkit.start({
   port: 1336,
 });
 
-const DataSpec = createDataFileSpec({
+const DataSpec = createDataFileDefinition({
   schema: z.object({
     text: z.string(),
   }),
   defaultValue: {
     text: 'Hello World',
   },
-  onPathChange: 'transfer',
 });
 
 const NAME_REGEX = /^[a-zA-Z0-9_-]+\.json$/;
@@ -40,7 +42,7 @@ const validateName = (name: string) => {
 };
 
 const FileDetails = () => {
-  const { data, updateData } = useDataFile(DataSpec);
+  const { data, updateData } = useDataFileContext(DataSpec);
   return (
     <Group direction="vertical">
       <Group>
@@ -74,7 +76,10 @@ const App = () => {
         />
       </Group>
       {filename && (
-        <DataSpec.Provider path={path.join(DATA_DIR, filename)}>
+        <DataSpec.Provider
+          path={path.join(DATA_DIR, filename)}
+          onPathChange="transfer"
+        >
           <FileDetails />
         </DataSpec.Provider>
       )}

--- a/packages/react-toolkit/src/data.tsx
+++ b/packages/react-toolkit/src/data.tsx
@@ -14,14 +14,32 @@ import type { ZodType } from 'zod';
 import { throttle } from 'lodash';
 import { dirname } from 'path';
 
-export type ProviderProps = {
+type WithPathChange = {
+  /**
+   * When the file path changes and the file does not yet exist,
+   * should the previous data be stored in the new file
+   * or should the new file be reset to the default value?
+   *
+   * @default 'defaultValue'
+   */
+  onPathChange?: 'transfer' | 'defaultValue';
+};
+
+type DataFileUsage = WithPathChange & {
+  /**
+   * The path to where the JSON data should be stored,
+   * this will be relative to the current working directory.
+   */
   path: string;
+};
+
+export type ProviderProps = DataFileUsage & {
   children: ReactNode;
 };
 
-type DataFileUpdater<T> = (update: (current: T) => T) => void;
+export type DataFileUpdater<T> = (update: (current: T) => T) => void;
 
-type DataFileContext<T> = {
+export type DataFileContext<T> = {
   data: T;
   updateData: DataFileUpdater<T>;
   /**
@@ -37,55 +55,281 @@ type DataFileContext<T> = {
   error: unknown;
 };
 
-type DataFile<T> = {
+export type DataFileDefinition<T> = {
   Provider: FC<ProviderProps>;
   context: Context<DataFileContext<T>>;
+  useDataFile: (props: DataFileUsage) => DataFileCore<T>;
 };
 
-type DataFileProps<T> = {
-  schema: ZodType<T>;
-  defaultValue: T;
-  /**
-   * When the file path changes and the file does not yet exist,
-   * should the previous data be stored in the new file
-   * or should the new file be reset to the default value?
-   *
-   * @default 'defaultValue'
-   */
-  onPathChange?: 'transfer' | 'defaultValue';
-};
-
-export function useDataFileData<T>(dataFile: DataFile<T>): T {
+export function useDataFileData<T>(dataFile: DataFileDefinition<T>): T {
   return useContext(dataFile.context).data;
 }
 
 export function useDataFileUpdater<T>(
-  dataFile: DataFile<T>,
+  dataFile: DataFileDefinition<T>,
 ): DataFileUpdater<T> {
   return useContext(dataFile.context).updateData;
 }
 
-export function useDataFile<T>(dataFile: DataFile<T>): DataFileContext<T> {
+/**
+ * Convenience hook to use the internal data-file context hook
+ */
+export function useDataFileContext<T>(
+  dataFile: DataFileDefinition<T>,
+): DataFileContext<T> {
   return useContext(dataFile.context);
 }
 
-type DataState<T> =
-  | { status: 'loading' }
+/**
+ * Convenience hook to use the internal data-file definition hook
+ * in a more react-like manner.
+ */
+export function useDataFile<T>(
+  dataFile: DataFileDefinition<T>,
+  usage: DataFileUsage,
+): DataFileCore<T> {
+  return dataFile.useDataFile(usage);
+}
+
+export type DataState<T> =
+  | {
+      status: 'loading';
+      /**
+       * The data is not yet loaded, so this will be undefined,
+       * but it's listed here as a property so that the data property can be
+       * directly used without a type-guard that uses `state`.
+       *
+       * This should hopefully also avoid situations where users may check for
+       * `state === 'ready'` instead of `state !== 'loading'`,
+       * and accidentally avoid displaying data that's available but unsaved.
+       */
+      data: undefined;
+    }
   | { status: 'error'; data: T | undefined; error: unknown }
   | { status: 'ready'; data: T };
 
-type DataFileState<T> = {
+type InternalDataFileState<T> = {
+  /**
+   * Set to true after
+   */
+  initialized: boolean;
   path: string | null;
   data: T | undefined;
   previousData: T | undefined;
   state: { state: 'error'; error: unknown } | { state: 'saved' | 'dirty' };
 };
 
-export function createDataFileSpec<T>({
+export type UseDataFileCoreProps<T> = WithPathChange & {
+  schema: ZodType<T>;
+  defaultValue: T;
+  path: string;
+};
+
+export type DataFileCore<T> = {
+  data: DataState<T>;
+  updateData: DataFileUpdater<T>;
+  saveData: () => void;
+};
+
+/**
+ * Primary hook for & logic for using data files.
+ */
+export function useDataFileCore<T>({
   schema,
   defaultValue,
+  path,
   onPathChange = 'defaultValue',
-}: DataFileProps<T>): DataFile<T> {
+}: UseDataFileCoreProps<T>): DataFileCore<T> {
+  /**
+   * Maintain all data in a ref so that we can dynamically throttle the
+   * writes to disk in a memoized function.
+   */
+  const state = useRef<InternalDataFileState<T>>({
+    initialized: false,
+    path: null,
+    data: undefined,
+    previousData: undefined,
+    state: {
+      state: 'saved',
+    },
+  });
+
+  // Ensure schema and default value are not changed after initialization
+  useEffect(() => {
+    if (!state.current.initialized) {
+      state.current.initialized = true;
+    } else {
+      throw new Error(
+        'Cannot change schema or defaultValue after initialization',
+      );
+    }
+  }, [schema, defaultValue]);
+
+  /**
+   * Processed version of the state,
+   * updates less regularly than the state,
+   * but more often than file writes to disk.
+   */
+  const [data, setData] = useState<DataState<T>>({
+    status: 'loading',
+    data: undefined,
+  });
+
+  const updateDataFromState = useMemo(
+    () => () => {
+      const data = state.current.data;
+
+      if (state.current.state.state === 'error') {
+        setData({
+          status: 'error',
+          error: state.current.state.error,
+          data,
+        });
+        return;
+      }
+
+      if (data === undefined) {
+        setData({
+          status: 'loading',
+          data: undefined,
+        });
+        return;
+      }
+
+      setData({
+        status: 'ready',
+        data,
+      });
+    },
+    [],
+  );
+
+  const saveData = useMemo(
+    () =>
+      throttle(
+        async () => {
+          if (state.current.state.state === 'saved') {
+            // No need to save data that has already been saved
+            return;
+          }
+
+          const currentPath = state.current.path;
+          const currentData = state.current.data;
+          if (!currentPath || currentData === undefined) {
+            return;
+          }
+
+          try {
+            const json = JSON.stringify(currentData, null, 2);
+            await fs.mkdir(dirname(currentPath), { recursive: true });
+            await fs.writeFile(currentPath, json, 'utf8');
+            if (
+              state.current.path === currentPath &&
+              state.current.data === currentData
+            ) {
+              state.current.state = { state: 'saved' };
+            }
+          } catch (error) {
+            if (
+              state.current.path === currentPath &&
+              state.current.data === currentData
+            ) {
+              state.current.state = { state: 'error', error };
+              updateDataFromState();
+            }
+          }
+        },
+        500,
+        {
+          // Write leading so that we always write to disk quickly when
+          // only single things have changed
+          leading: true,
+          // Trailing is important otherwise we may lose data
+          trailing: true,
+        },
+      ),
+    [],
+  );
+
+  useEffect(() => {
+    // Set the new path, and attempt to load the file
+    state.current = {
+      ...state.current,
+      path,
+      data: undefined,
+      previousData: state.current.data ?? state.current.previousData,
+      state: {
+        state: 'saved',
+      },
+    };
+    fs.readFile(path, 'utf8')
+      .then((data) => {
+        const parsedData = schema.parse(JSON.parse(data));
+        if (state.current.path === path) {
+          state.current.data = parsedData;
+          state.current.state = { state: 'saved' };
+          updateDataFromState();
+        }
+      })
+      .catch((error) => {
+        // If file doesn't exist, then create it using the default value
+        if (state.current.path !== path) {
+          // Ignore error if path has changed
+          return;
+        }
+        if (error.code === 'ENOENT') {
+          console.log('Creating new file');
+          // Initialise the state, and then write it to disk
+          const initialData =
+            onPathChange === 'transfer' &&
+            state.current.previousData !== undefined
+              ? state.current.previousData
+              : defaultValue;
+          state.current.data = initialData;
+          state.current.state = { state: 'dirty' };
+          saveData();
+          updateDataFromState();
+          return;
+        }
+
+        state.current.state = { state: 'error', error };
+        updateDataFromState();
+      });
+  }, [path, onPathChange]);
+
+  const updateData: DataFileUpdater<T> = useMemo(
+    () => (update) => {
+      if (state.current.path !== path) {
+        // Ignore any requests to update a file if the path has been changed
+        return;
+      }
+      if (state.current.data === undefined) {
+        throw new Error('Attempt to update data before it has been loaded');
+      }
+      state.current.data = update(state.current.data);
+      state.current.state = { state: 'dirty' };
+      saveData();
+      updateDataFromState();
+    },
+    [path],
+  );
+
+  return {
+    data,
+    updateData,
+    saveData,
+  };
+}
+
+export type CreateDataFileDefinitionProps<T> = {
+  schema: ZodType<T>;
+  defaultValue: T;
+};
+
+export function createDataFileDefinition<T>({
+  schema,
+  defaultValue,
+}: CreateDataFileDefinitionProps<T>): DataFileDefinition<T> {
   const context = createContext<DataFileContext<T>>({
     data: defaultValue,
     updateData: () => {
@@ -97,168 +341,27 @@ export function createDataFileSpec<T>({
     error: undefined,
   });
 
+  const useDataFile = ({
+    path,
+    onPathChange,
+  }: DataFileUsage): DataFileCore<T> =>
+    useDataFileCore({
+      schema,
+      defaultValue,
+      path,
+      onPathChange,
+    });
+
   /**
-   * Create a specific provider function function component
+   * Create a specific provider function function component,
+   * that will set up the context,
+   * and create a boundary that only displays children once the data has loaded.
    */
-  const Provider: FC<ProviderProps> = ({ path, children }) => {
-    /**
-     * Maintain all data in a ref so that we can dynamically throttle the
-     * writes to disk in a memoized function.
-     */
-    const state = useRef<DataFileState<T>>({
-      path: null,
-      data: undefined,
-      previousData: undefined,
-      state: {
-        state: 'saved',
-      },
+  const Provider: FC<ProviderProps> = ({ path, onPathChange, children }) => {
+    const { data, updateData, saveData } = useDataFile({
+      path,
+      onPathChange,
     });
-
-    /**
-     * Processed version of the state,
-     * updates less regularly than the state,
-     * but more often than file writes to disk.
-     */
-    const [data, setData] = useState<DataState<T>>({
-      status: 'loading',
-    });
-
-    const updateDataFromState = useMemo(
-      () => () => {
-        const data = state.current.data;
-
-        if (state.current.state.state === 'error') {
-          setData({
-            status: 'error',
-            error: state.current.state.error,
-            data,
-          });
-          return;
-        }
-
-        if (data === undefined) {
-          setData({
-            status: 'loading',
-          });
-          return;
-        }
-
-        setData({
-          status: 'ready',
-          data,
-        });
-      },
-      [],
-    );
-
-    const requestFileWriteToDisk = useMemo(
-      () =>
-        throttle(
-          async () => {
-            if (state.current.state.state === 'saved') {
-              // No need to save data that has already been saved
-              return;
-            }
-
-            const currentPath = state.current.path;
-            const currentData = state.current.data;
-            if (!currentPath || currentData === undefined) {
-              return;
-            }
-
-            try {
-              const json = JSON.stringify(currentData, null, 2);
-              await fs.mkdir(dirname(currentPath), { recursive: true });
-              await fs.writeFile(currentPath, json, 'utf8');
-              if (
-                state.current.path === currentPath &&
-                state.current.data === currentData
-              ) {
-                state.current.state = { state: 'saved' };
-              }
-            } catch (error) {
-              if (
-                state.current.path === currentPath &&
-                state.current.data === currentData
-              ) {
-                state.current.state = { state: 'error', error };
-                updateDataFromState();
-              }
-            }
-          },
-          500,
-          {
-            // Write leading so that we always write to disk quickly when
-            // only single things have changed
-            leading: true,
-            // Trailing is important otherwise we may lose data
-            trailing: true,
-          },
-        ),
-      [],
-    );
-
-    useEffect(() => {
-      // Set the new path, and attempt to load the file
-      state.current = {
-        path,
-        data: undefined,
-        previousData: state.current.data ?? state.current.previousData,
-        state: {
-          state: 'saved',
-        },
-      };
-      fs.readFile(path, 'utf8')
-        .then((data) => {
-          const parsedData = schema.parse(JSON.parse(data));
-          if (state.current.path === path) {
-            state.current.data = parsedData;
-            state.current.state = { state: 'saved' };
-            updateDataFromState();
-          }
-        })
-        .catch((error) => {
-          // If file doesn't exist, then create it using the default value
-          if (state.current.path !== path) {
-            // Ignore error if path has changed
-            return;
-          }
-          if (error.code === 'ENOENT') {
-            console.log('Creating new file');
-            // Initialise the state, and then write it to disk
-            const initialData =
-              onPathChange === 'transfer' &&
-              state.current.previousData !== undefined
-                ? state.current.previousData
-                : defaultValue;
-            state.current.data = initialData;
-            state.current.state = { state: 'dirty' };
-            requestFileWriteToDisk();
-            updateDataFromState();
-            return;
-          }
-
-          state.current.state = { state: 'error', error };
-          updateDataFromState();
-        });
-    }, [path]);
-
-    const updateData: DataFileUpdater<T> = useMemo(
-      () => (update) => {
-        if (state.current.path !== path) {
-          // Ignore any requests to update a file if the path has been changed
-          return;
-        }
-        if (state.current.data === undefined) {
-          throw new Error('Attempt to update data before it has been loaded');
-        }
-        state.current.data = update(state.current.data);
-        state.current.state = { state: 'dirty' };
-        requestFileWriteToDisk();
-        updateDataFromState();
-      },
-      [path],
-    );
 
     const providedContext: DataFileContext<T> = useMemo(
       () => ({
@@ -267,7 +370,7 @@ export function createDataFileSpec<T>({
             ? data.data
             : defaultValue,
         updateData,
-        saveData: requestFileWriteToDisk,
+        saveData,
         error: data.status === 'error' ? data.error : undefined,
       }),
       [data, updateData],
@@ -285,5 +388,6 @@ export function createDataFileSpec<T>({
   return {
     Provider,
     context,
+    useDataFile,
   };
 }

--- a/packages/react-toolkit/src/types.ts
+++ b/packages/react-toolkit/src/types.ts
@@ -44,7 +44,7 @@ import type {
 } from '@arcanejs/toolkit/components/timeline';
 import type { Ref } from 'react';
 
-type Child = JSX.Element | string | null | undefined;
+type Child = JSX.Element | string | null | undefined | boolean;
 type Children = Child | Child[];
 
 export interface LightDeskIntrinsicElements {


### PR DESCRIPTION
Allow for usage without a provider by exposing the core hooks as a separate exported function,
which will avoid the need for introducing multiple components or using contexts when users are happy to implement their own loading display.