### PR TITLE
Use vertical group be default for root

### DIFF
--- a/.changeset/warm-waves-dance.md
+++ b/.changeset/warm-waves-dance.md
@@ -1,0 +1,5 @@
+---
+'@arcanejs/react-toolkit': patch
+---
+
+Use vertical group be default for root group

--- a/packages/react-toolkit/src/index.tsx
+++ b/packages/react-toolkit/src/index.tsx
@@ -300,7 +300,7 @@ export const ToolkitRenderer = {
     container: ld.Toolkit,
     rootGroupProps?: GroupProps,
   ) => {
-    const group = new ld.Group(rootGroupProps);
+    const group = new ld.Group({ direction: 'vertical', ...rootGroupProps });
     container.setRoot(group);
     ToolkitRenderer.renderGroup(component, group);
   },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a default vertical layout for the root group in the `@arcanejs/react-toolkit` package, enhancing the visual arrangement of child components.

- **Bug Fixes**
	- Improved the initialization of the `ld.Group` instance to ensure consistent vertical grouping behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->