### PR TITLE
Introduce color picker, SliderButton gradients, and general Rect and SliderButton improvements

### DIFF
--- a/.changeset/dull-icons-occur.md
+++ b/.changeset/dull-icons-occur.md
@@ -1,0 +1,8 @@
+---
+'@arcanejs/react-toolkit': minor
+---
+
+Introduce new `HslColorPicker` composite component
+
+Introduce a new component that can be used to select different colors,
+build from `Group`, `Rect` and `SliderButton` components.

--- a/.changeset/heavy-bags-approve.md
+++ b/.changeset/heavy-bags-approve.md
@@ -1,0 +1,6 @@
+---
+'@arcanejs/toolkit-frontend': patch
+'@arcanejs/toolkit': patch
+---
+
+Improve display of SliderButton and Rect when vertical

--- a/.changeset/red-cameras-tell.md
+++ b/.changeset/red-cameras-tell.md
@@ -1,0 +1,7 @@
+---
+'@arcanejs/toolkit-frontend': minor
+'@arcanejs/protocol': minor
+'@arcanejs/toolkit': minor
+---
+
+Allow Rect and SliderButtons to grow

--- a/.changeset/unlucky-badgers-share.md
+++ b/.changeset/unlucky-badgers-share.md
@@ -1,0 +1,7 @@
+---
+'@arcanejs/toolkit-frontend': minor
+'@arcanejs/protocol': minor
+'@arcanejs/toolkit': minor
+---
+
+Introduce gradients on SliderButton

--- a/examples/react/package.json
+++ b/examples/react/package.json
@@ -8,6 +8,7 @@
     "build": "tsc --noEmit",
     "start": "node --import=tsx --conditions=@arcanejs/source",
     "start:button-adder": "pnpm start src/button-adder",
+    "start:color-picker": "pnpm start src/color-picker",
     "start:controlled-vs-uncontrolled": "pnpm start src/controlled-vs-uncontrolled",
     "start:counter": "pnpm start src/counter",
     "start:data-file": "pnpm start src/data-file",

--- a/examples/react/src/color-picker.tsx
+++ b/examples/react/src/color-picker.tsx
@@ -1,0 +1,82 @@
+import { useState } from 'react';
+import { Toolkit } from '@arcanejs/toolkit';
+import { HUE_GRADIENT } from '@arcanejs/toolkit/util';
+import {
+  ToolkitRenderer,
+  Group,
+  SliderButton,
+  Rect,
+} from '@arcanejs/react-toolkit';
+import pino from 'pino';
+
+const toolkit = new Toolkit({
+  log: pino({
+    level: 'info',
+    transport: {
+      target: 'pino-pretty',
+    },
+  }),
+});
+
+toolkit.start({
+  mode: 'automatic',
+  port: 1338,
+});
+
+const ColorPicker = () => {
+  const [alpha, setAlpha] = useState(1);
+  const [hue, setHue] = useState(0);
+  const [sat, setSat] = useState(100);
+  const [lightness, setLightness] = useState(50);
+
+  return (
+    <Group direction="vertical">
+      <Rect color={`hsl(${hue}deg ${sat}% ${lightness}% / ${alpha})`} />
+      <SliderButton
+        value={hue}
+        onChange={setHue}
+        min={0}
+        max={360}
+        step={1}
+        gradient={HUE_GRADIENT}
+      />
+      <SliderButton
+        value={sat}
+        onChange={setSat}
+        min={0}
+        max={100}
+        step={1}
+        gradient={[
+          { color: `hsl(${hue}deg 0% ${lightness}%)`, position: 0 },
+          { color: `hsl(${hue}deg 50% ${lightness}%)`, position: 0.5 },
+          { color: `hsl(${hue}deg 100% ${lightness}%)`, position: 1 },
+        ]}
+      />
+      <SliderButton
+        value={lightness}
+        onChange={setLightness}
+        min={0}
+        max={100}
+        step={1}
+        gradient={[
+          { color: `hsl(${hue}deg ${sat}% 0%)`, position: 0 },
+          { color: `hsl(${hue}deg ${sat}% 50%)`, position: 0.5 },
+          { color: `hsl(${hue}deg ${sat}% 100%)`, position: 1 },
+        ]}
+      />
+      <SliderButton
+        value={alpha}
+        onChange={setAlpha}
+        min={0}
+        max={1}
+        step={0.01}
+        gradient={[
+          { color: `hsla(${hue}deg ${sat}% ${lightness}% / 0)`, position: 0 },
+          { color: `hsla(${hue}deg ${sat}% ${lightness}% / 1)`, position: 1 },
+        ]}
+      />
+    </Group>
+  );
+};
+
+ToolkitRenderer.render(<ColorPicker />, toolkit);

--- a/examples/react/src/color-picker.tsx
+++ b/examples/react/src/color-picker.tsx
@@ -1,12 +1,7 @@
 import { useState } from 'react';
 import { Toolkit } from '@arcanejs/toolkit';
-import { HUE_GRADIENT } from '@arcanejs/toolkit/util';
-import {
-  ToolkitRenderer,
-  Group,
-  SliderButton,
-  Rect,
-} from '@arcanejs/react-toolkit';
+import { ToolkitRenderer, Group } from '@arcanejs/react-toolkit';
+import { HslColor, HslColorPicker } from '@arcanejs/react-toolkit/colors';
 import pino from 'pino';
 
 const toolkit = new Toolkit({
@@ -24,56 +19,23 @@ toolkit.start({
 });
 
 const ColorPicker = () => {
-  const [alpha, setAlpha] = useState(1);
-  const [hue, setHue] = useState(0);
-  const [sat, setSat] = useState(100);
-  const [lightness, setLightness] = useState(50);
+  const [color, setColor] = useState<HslColor>({
+    hue: 0,
+    saturation: 100,
+    lightness: 50,
+    alpha: 1,
+  });
 
   return (
     <Group direction="vertical">
-      <Rect color={`hsl(${hue}deg ${sat}% ${lightness}% / ${alpha})`} />
-      <SliderButton
-        value={hue}
-        onChange={setHue}
-        min={0}
-        max={360}
-        step={1}
-        gradient={HUE_GRADIENT}
-      />
-      <SliderButton
-        value={sat}
-        onChange={setSat}
-        min={0}
-        max={100}
-        step={1}
-        gradient={[
-          { color: `hsl(${hue}deg 0% ${lightness}%)`, position: 0 },
-          { color: `hsl(${hue}deg 50% ${lightness}%)`, position: 0.5 },
-          { color: `hsl(${hue}deg 100% ${lightness}%)`, position: 1 },
-        ]}
-      />
-      <SliderButton
-        value={lightness}
-        onChange={setLightness}
-        min={0}
-        max={100}
-        step={1}
-        gradient={[
-          { color: `hsl(${hue}deg ${sat}% 0%)`, position: 0 },
-          { color: `hsl(${hue}deg ${sat}% 50%)`, position: 0.5 },
-          { color: `hsl(${hue}deg ${sat}% 100%)`, position: 1 },
-        ]}
-      />
-      <SliderButton
-        value={alpha}
-        onChange={setAlpha}
-        min={0}
-        max={1}
-        step={0.01}
-        gradient={[
-          { color: `hsla(${hue}deg ${sat}% ${lightness}% / 0)`, position: 0 },
-          { color: `hsla(${hue}deg ${sat}% ${lightness}% / 1)`, position: 1 },
-        ]}
+      <HslColorPicker color={color} onChange={setColor} showAlpha />
+      <HslColorPicker
+        color={color}
+        onChange={setColor}
+        groupProps={{
+          border: true,
+          direction: 'vertical',
+        }}
       />
     </Group>
   );

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -5,6 +5,17 @@ type BaseComponent = {
   key: number;
 };
 
+export type Gradient = Array<{
+  /**
+   * CSS color value
+   */
+  color: string;
+  /**
+   * Position of the color in the gradient, between 0 and 1
+   */
+  position: number;
+}>;
+
 export type ButtonComponent = BaseComponent & {
   component: 'button';
   text: string;
@@ -62,6 +73,7 @@ export type SliderButtonComponent = BaseComponent & {
   max: number;
   step: number;
   value: number | null;
+  gradient?: Gradient;
 };
 
 export type SwitchComponent = BaseComponent & {

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -65,6 +65,10 @@ export type LabelComponent = BaseComponent & {
 export type RectComponent = BaseComponent & {
   component: 'rect';
   color: string;
+  /**
+   * Set to true if the component should increase its size to fill the available space.
+   */
+  grow?: boolean;
 };
 
 export type SliderButtonComponent = BaseComponent & {
@@ -74,6 +78,10 @@ export type SliderButtonComponent = BaseComponent & {
   step: number;
   value: number | null;
   gradient?: Gradient;
+  /**
+   * Set to true if the component should increase its size to fill the available space.
+   */
+  grow?: boolean;
 };
 
 export type SwitchComponent = BaseComponent & {

--- a/packages/react-toolkit/package.json
+++ b/packages/react-toolkit/package.json
@@ -25,6 +25,12 @@
       "require": "./dist/index.js",
       "types": "./dist/index.d.ts"
     },
+    "./colors": {
+      "@arcanejs/source": "./src/colors.tsx",
+      "import": "./dist/colors.mjs",
+      "require": "./dist/colors.js",
+      "types": "./dist/colors.d.ts"
+    },
     "./data": {
       "@arcanejs/source": "./src/data.tsx",
       "import": "./dist/data.mjs",

--- a/packages/react-toolkit/src/colors.tsx
+++ b/packages/react-toolkit/src/colors.tsx
@@ -1,0 +1,159 @@
+import React, { useCallback } from 'react';
+import { HUE_GRADIENT } from '@arcanejs/toolkit/util';
+
+import { Group, Rect, SliderButton } from './components';
+import { LightDeskIntrinsicElements } from './types';
+
+export type HslColor = {
+  /**
+   * Hue in degrees, between 0-360.
+   */
+  hue: number;
+  /**
+   * Percentage saturation, between 0-100.
+   */
+  saturation: number;
+  /**
+   * Percentage lightness, between 0-100.
+   */
+  lightness: number;
+  /**
+   * Alpha channel, between 0-1.
+   */
+  alpha?: number;
+};
+
+export type HslColorPickerProps = {
+  color: HslColor;
+  onChange: (update: (current: HslColor) => HslColor) => void;
+  /**
+   * Should the alpha channel be shown?
+   *
+   * @default false
+   */
+  showAlpha?: boolean;
+  /**
+   * Props to pass to the group component.
+   *
+   * @see {@link DEFAULT_GROUP_PROPS}
+   */
+  groupProps?: LightDeskIntrinsicElements['group'];
+};
+
+/**
+ * The default values given to the group component for the color picker.
+ */
+const DEFAULT_GROUP_PROPS: LightDeskIntrinsicElements['group'] = {
+  wrap: true,
+  direction: 'horizontal',
+};
+
+export const HslColorPicker: React.FC<HslColorPickerProps> = ({
+  color,
+  onChange,
+  showAlpha = false,
+  groupProps,
+}) => {
+  const { hue, saturation, lightness, alpha = 1 } = color;
+
+  const setHue = useCallback(
+    (newHue: number) => {
+      onChange((current) => ({
+        ...current,
+        hue: newHue,
+      }));
+    },
+    [onChange],
+  );
+
+  const setSat = useCallback(
+    (newSat: number) => {
+      onChange((current) => ({
+        ...current,
+        saturation: newSat,
+      }));
+    },
+    [onChange],
+  );
+
+  const setLightness = useCallback(
+    (newLightness: number) => {
+      onChange((current) => ({
+        ...current,
+        lightness: newLightness,
+      }));
+    },
+    [onChange],
+  );
+
+  const setAlpha = useCallback(
+    (newAlpha: number) => {
+      onChange((current) => ({
+        ...current,
+        alpha: newAlpha,
+      }));
+    },
+    [onChange],
+  );
+
+  return (
+    <Group {...DEFAULT_GROUP_PROPS} {...groupProps}>
+      <Rect color={`hsl(${hue}deg ${saturation}% ${lightness}% / ${alpha})`} />
+      <SliderButton
+        value={hue}
+        onChange={setHue}
+        min={0}
+        max={360}
+        step={1}
+        gradient={HUE_GRADIENT}
+        grow
+      />
+      <SliderButton
+        value={saturation}
+        onChange={setSat}
+        min={0}
+        max={100}
+        step={1}
+        gradient={[
+          { color: `hsl(${hue}deg 0% ${lightness}%)`, position: 0 },
+          { color: `hsl(${hue}deg 50% ${lightness}%)`, position: 0.5 },
+          { color: `hsl(${hue}deg 100% ${lightness}%)`, position: 1 },
+        ]}
+        grow
+      />
+      <SliderButton
+        value={lightness}
+        onChange={setLightness}
+        min={0}
+        max={100}
+        step={1}
+        gradient={[
+          { color: `hsl(${hue}deg ${saturation}% 0%)`, position: 0 },
+          { color: `hsl(${hue}deg ${saturation}% 50%)`, position: 0.5 },
+          { color: `hsl(${hue}deg ${saturation}% 100%)`, position: 1 },
+        ]}
+        grow
+      />
+      {showAlpha && (
+        <SliderButton
+          value={alpha}
+          onChange={setAlpha}
+          min={0}
+          max={1}
+          step={0.01}
+          gradient={[
+            {
+              color: `hsla(${hue}deg ${saturation}% ${lightness}% / 0)`,
+              position: 0,
+            },
+            {
+              color: `hsla(${hue}deg ${saturation}% ${lightness}% / 1)`,
+              position: 1,
+            },
+          ]}
+          grow
+        />
+      )}
+    </Group>
+  );
+};

--- a/packages/react-toolkit/tsup.config.ts
+++ b/packages/react-toolkit/tsup.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'tsup';
 
 export default defineConfig({
-  entry: ['src/index.tsx', 'src/data.tsx', 'src/logging.ts'],
+  entry: ['src/index.tsx', 'src/colors.tsx', 'src/data.tsx', 'src/logging.ts'],
   format: ['cjs', 'esm'],
   splitting: true,
   dts: true,

--- a/packages/toolkit-frontend/src/components/core/index.ts
+++ b/packages/toolkit-frontend/src/components/core/index.ts
@@ -1,1 +1,11 @@
 export { Icon } from './icon';
+
+export const TRANSPARENCY_SVG = `
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10">
+  <rect width="10px" height="10px" fill="#333" />
+  <rect width="5px" height="5px" fill="#ddd" y="5"/>
+  <rect width="5px" height="5px" fill="#ddd" x="5"/>
+</svg>
+`;
+
+export const TRANSPARENCY_SVG_URI = `data:image/svg+xml,${encodeURIComponent(TRANSPARENCY_SVG)}`;

--- a/packages/toolkit-frontend/src/components/rect.tsx
+++ b/packages/toolkit-frontend/src/components/rect.tsx
@@ -3,14 +3,7 @@ import { styled } from 'styled-components';
 
 import * as proto from '@arcanejs/protocol';
 import { THEME } from '../styling';
-
-const TRANSPARENCY_SVG = `
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10">
-  <rect width="10px" height="10px" fill="#333" />
-  <rect width="5px" height="5px" fill="#ddd" y="5"/>
-  <rect width="5px" height="5px" fill="#ddd" x="5"/>
-</svg>
-`;
+import { TRANSPARENCY_SVG_URI } from './core';
 
 interface Props {
   className?: string;
@@ -22,7 +15,7 @@ const Wrapper = styled.div`
   height: 30px;
   border-radius: 3px;
   overflow: hidden;
-  background: url('data:image/svg+xml,${encodeURIComponent(TRANSPARENCY_SVG)}');
+  background: url('${TRANSPARENCY_SVG_URI}');
   background-repeat: repeat;
   background-size: 10px;
   border: 1px solid ${THEME.borderDark};

--- a/packages/toolkit-frontend/src/components/rect.tsx
+++ b/packages/toolkit-frontend/src/components/rect.tsx
@@ -2,6 +2,7 @@ import React, { FC } from 'react';
 import { styled } from 'styled-components';
 
 import * as proto from '@arcanejs/protocol';
+import { THEME } from '../styling';
 
 const TRANSPARENCY_SVG = `
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10">
@@ -17,13 +18,14 @@ interface Props {
 }
 
 const Wrapper = styled.div`
-  width: 30px;
+  min-width: 30px;
   height: 30px;
   border-radius: 3px;
   overflow: hidden;
   background: url('data:image/svg+xml,${encodeURIComponent(TRANSPARENCY_SVG)}');
   background-repeat: repeat;
   background-size: 10px;
+  border: 1px solid ${THEME.borderDark};
 `;
 
 const Inner = styled.div`

--- a/packages/toolkit-frontend/src/components/rect.tsx
+++ b/packages/toolkit-frontend/src/components/rect.tsx
@@ -4,11 +4,14 @@ import { styled } from 'styled-components';
 import * as proto from '@arcanejs/protocol';
 import { THEME } from '../styling';
 import { TRANSPARENCY_SVG_URI } from './core';
+import { calculateClass } from '../util';
 
 interface Props {
   className?: string;
   info: proto.RectComponent;
 }
+
+const CLS_GROW = 'grow';
 
 const Wrapper = styled.div`
   min-width: 30px;
@@ -19,6 +22,10 @@ const Wrapper = styled.div`
   background-repeat: repeat;
   background-size: 10px;
   border: 1px solid ${THEME.borderDark};
+
+  &.${CLS_GROW} {
+    flex-grow: 1;
+  }
 `;
 
 const Inner = styled.div`
@@ -27,7 +34,7 @@ const Inner = styled.div`
 `;
 
 const Rect: FC<Props> = ({ className, info }) => (
-  <Wrapper className={className}>
+  <Wrapper className={calculateClass(className, info.grow && CLS_GROW)}>
     <Inner style={{ backgroundColor: info.color }} />
   </Wrapper>
 );

--- a/packages/toolkit-frontend/src/components/slider-button.tsx
+++ b/packages/toolkit-frontend/src/components/slider-button.tsx
@@ -203,8 +203,8 @@ const SliderButton: FC<Props> = (props) => {
 
 const StyledSliderButton: FC<Props> = styled(SliderButton)`
   position: relative;
-  width: 100px;
-  height: 30px;
+  min-width: 100px;
+  min-height: 30px;
 
   @media (max-width: 500px) {
     flex-basis: 100%;

--- a/packages/toolkit/src/backend/components/rect.ts
+++ b/packages/toolkit/src/backend/components/rect.ts
@@ -3,9 +3,7 @@ import { IDMap } from '../util/id-map';
 
 import { Base } from './base';
 
-type InternalProps = {
-  color: string;
-};
+type InternalProps = Pick<proto.RectComponent, 'color' | 'grow'>;
 
 export type Props = Partial<InternalProps>;
 
@@ -28,7 +26,7 @@ export class Rect extends Base<InternalProps> {
     return {
       component: 'rect',
       key: idMap.getId(this),
-      color: this.props.color,
+      ...this.props,
     };
   }
 

--- a/packages/toolkit/src/backend/components/slider-button.ts
+++ b/packages/toolkit/src/backend/components/slider-button.ts
@@ -13,6 +13,7 @@ type InternalProps = {
   step: number;
   value?: number;
   defaultValue?: number;
+  gradient?: proto.Gradient;
 };
 
 type RequiredProps = 'value';
@@ -58,6 +59,7 @@ export class SliderButton
       max: this.props.max,
       step: this.props.step,
       value: this._value,
+      gradient: this.props.gradient,
     };
   }
 

--- a/packages/toolkit/src/backend/components/slider-button.ts
+++ b/packages/toolkit/src/backend/components/slider-button.ts
@@ -7,13 +7,12 @@ export type Events = {
   change: (value: number) => void | Promise<void>;
 };
 
-type InternalProps = {
-  min: number;
-  max: number;
-  step: number;
+type InternalProps = Pick<
+  proto.SliderButtonComponent,
+  'min' | 'max' | 'step' | 'gradient' | 'grow'
+> & {
   value?: number;
   defaultValue?: number;
-  gradient?: proto.Gradient;
 };
 
 type RequiredProps = 'value';
@@ -60,6 +59,7 @@ export class SliderButton
       step: this.props.step,
       value: this._value,
       gradient: this.props.gradient,
+      grow: this.props.grow,
     };
   }
 

--- a/packages/toolkit/src/backend/util/color.ts
+++ b/packages/toolkit/src/backend/util/color.ts
@@ -1,0 +1,14 @@
+import { Gradient } from '@arcanejs/protocol';
+
+/**
+ * Rainbow gradient used for hue slider values.
+ */
+export const HUE_GRADIENT: Gradient = [
+  { color: 'red', position: 0 },
+  { color: 'yellow', position: 60 / 360 },
+  { color: 'green', position: 120 / 360 },
+  { color: 'cyan', position: 180 / 360 },
+  { color: 'blue', position: 240 / 360 },
+  { color: 'magenta', position: 300 / 360 },
+  { color: 'red', position: 1 },
+];

--- a/packages/toolkit/src/backend/util/index.ts
+++ b/packages/toolkit/src/backend/util/index.ts
@@ -1,1 +1,2 @@
 export * from './id-map';
+export * from './color';


### PR DESCRIPTION
* Allow for custom gradients to be defined for `SliderButton` components
* Introduce a composite component in `react-toolkit` called `HslColorPicker` that allows creation of color picker component that uses `Rect` and `SliderButton` components, making use of the new gradient feature.
* Various improvements to the display of `Rect` and `SliderButton` components.