### PR TITLE
Refactor events to always use props

### DIFF
--- a/.changeset/big-ligers-applaud.md
+++ b/.changeset/big-ligers-applaud.md
@@ -1,0 +1,6 @@
+---
+'@arcanejs/react-toolkit': minor
+'@arcanejs/toolkit': minor
+---
+
+Refactor event listener usage to use props

--- a/.changeset/lazy-lies-shop.md
+++ b/.changeset/lazy-lies-shop.md
@@ -1,0 +1,9 @@
+---
+'@arcanejs/toolkit-frontend': patch
+'@arcanejs/react-toolkit': patch
+'@arcanejs/protocol': patch
+'@arcanejs/toolkit': patch
+'@arcanejs/diff': patch
+---
+
+Reorder package exports to remove esbuild warnings

--- a/packages/diff/package.json
+++ b/packages/diff/package.json
@@ -23,21 +23,21 @@
   "exports": {
     ".": {
       "@arcanejs/source": "./src/index.ts",
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
-      "require": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "require": "./dist/index.js"
     },
     "./diff": {
       "@arcanejs/source": "./src/diff.ts",
+      "types": "./dist/diff.d.ts",
       "import": "./dist/diff.mjs",
-      "require": "./dist/diff.js",
-      "types": "./dist/diff.d.ts"
+      "require": "./dist/diff.js"
     },
     "./patch": {
       "@arcanejs/source": "./src/patch.ts",
+      "types": "./dist/patch.d.ts",
       "import": "./dist/patch.mjs",
-      "require": "./dist/patch.js",
-      "types": "./dist/patch.d.ts"
+      "require": "./dist/patch.js"
     },
     "./package.json": "./package.json"
   },

--- a/packages/react-toolkit/package.json
+++ b/packages/react-toolkit/package.json
@@ -21,27 +21,27 @@
   "exports": {
     ".": {
       "@arcanejs/source": "./src/index.tsx",
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
-      "require": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "require": "./dist/index.js"
     },
     "./colors": {
       "@arcanejs/source": "./src/colors.tsx",
+      "types": "./dist/colors.d.ts",
       "import": "./dist/colors.mjs",
-      "require": "./dist/colors.js",
-      "types": "./dist/colors.d.ts"
+      "require": "./dist/colors.js"
     },
     "./data": {
       "@arcanejs/source": "./src/data.tsx",
+      "types": "./dist/data.d.ts",
       "import": "./dist/data.mjs",
-      "require": "./dist/data.js",
-      "types": "./dist/data.d.ts"
+      "require": "./dist/data.js"
     },
     "./logging": {
       "@arcanejs/source": "./src/logging.ts",
+      "types": "./dist/logging.d.ts",
       "import": "./dist/logging.mjs",
-      "require": "./dist/logging.js",
-      "types": "./dist/logging.d.ts"
+      "require": "./dist/logging.js"
     },
     "./package.json": "./package.json"
   },

--- a/packages/react-toolkit/src/index.tsx
+++ b/packages/react-toolkit/src/index.tsx
@@ -50,79 +50,6 @@ const isType = <T extends keyof LightDeskIntrinsicElements>(
 const canSetProps = (instance: ld.Component): instance is Base<unknown> =>
   instance instanceof Base;
 
-const updateListener = <
-  EventName extends string,
-  Property extends string,
-  Listener,
->(
-  eventName: EventName,
-  property: Property,
-  instance: {
-    removeListener: (e: EventName, l: Listener) => void;
-    addListener: (e: EventName, l: Listener) => void;
-  },
-  prevProps: {
-    [key in Property]?: Listener;
-  },
-  nextProps: {
-    [key in Property]?: Listener;
-  },
-) => {
-  const prev = prevProps[property];
-  const next = nextProps[property];
-  if (prev !== next) {
-    prev && instance.removeListener(eventName, prev);
-    next && instance.addListener(eventName, next);
-  }
-};
-
-const updateListeners = (
-  type: Type,
-  instance: ld.Component,
-  prevProps: Props,
-  nextProps: Props,
-) => {
-  if (isType('button', type, prevProps) && isType('button', type, nextProps)) {
-    if (instance instanceof ld.Button) {
-      updateListener('click', 'onClick', instance, prevProps, nextProps);
-    }
-  } else if (
-    isType('group', type, prevProps) &&
-    isType('group', type, nextProps)
-  ) {
-    if (instance instanceof ld.Group) {
-      updateListener(
-        'title-changed',
-        'onTitleChanged',
-        instance,
-        prevProps,
-        nextProps,
-      );
-    }
-  } else if (
-    isType('slider-button', type, prevProps) &&
-    isType('slider-button', type, nextProps)
-  ) {
-    if (instance instanceof ld.SliderButton) {
-      updateListener('change', 'onChange', instance, prevProps, nextProps);
-    }
-  } else if (
-    isType('switch', type, prevProps) &&
-    isType('switch', type, nextProps)
-  ) {
-    if (instance instanceof ld.Switch) {
-      updateListener('change', 'onChange', instance, prevProps, nextProps);
-    }
-  } else if (
-    isType('text-input', type, prevProps) &&
-    isType('text-input', type, nextProps)
-  ) {
-    if (instance instanceof ld.TextInput) {
-      updateListener('change', 'onChange', instance, prevProps, nextProps);
-    }
-  }
-};
-
 const hostConfig: LightDeskHostConfig = {
   supportsMutation: true,
   supportsPersistence: false,
@@ -157,14 +84,13 @@ const hostConfig: LightDeskHostConfig = {
   commitUpdate(
     instance,
     updatePayload,
-    type,
-    prevProps,
-    nextProps,
+    _type,
+    _prevProps,
+    _nextProps,
     _internalHandle,
   ) {
     if (canSetProps(instance)) {
       instance.setProps(updatePayload);
-      updateListeners(type, instance, prevProps, nextProps);
     } else {
       throw new Error(`Unexpected Instance: ${instance}`);
     }
@@ -197,7 +123,6 @@ const hostConfig: LightDeskHostConfig = {
       instance = new ld.Timeline(props);
     }
     if (instance) {
-      updateListeners(type, instance, {}, props);
       return instance;
     } else {
       throw new Error(`Not implemented type: ${type}`);

--- a/packages/toolkit-frontend/package.json
+++ b/packages/toolkit-frontend/package.json
@@ -16,27 +16,27 @@
   "exports": {
     ".": {
       "@arcanejs/source": "./src/components/index.tsx",
+      "types": "./dist/components/index.d.ts",
       "import": "./dist/components/index.mjs",
-      "require": "./dist/components/index.js",
-      "types": "./dist/components/index.d.ts"
+      "require": "./dist/components/index.js"
     },
     "./components/core": {
       "@arcanejs/source": "./src/components/core/index.ts",
+      "types": "./dist/components/core/index.d.ts",
       "import": "./dist/components/core/index.mjs",
-      "require": "./dist/components/core/index.js",
-      "types": "./dist/components/core/index.d.ts"
-    },
-    "./util": {
-      "@arcanejs/source": "./src/util/index.ts",
-      "import": "./dist/util/index.mjs",
-      "require": "./dist/util/index.js",
-      "types": "./dist/util/index.d.ts"
+      "require": "./dist/components/core/index.js"
     },
     "./styling": {
       "@arcanejs/source": "./src/styling.ts",
+      "types": "./dist/styling.d.ts",
       "import": "./dist/styling.mjs",
-      "require": "./dist/styling.js",
-      "types": "./dist/styling.d.ts"
+      "require": "./dist/styling.js"
+    },
+    "./util": {
+      "@arcanejs/source": "./src/util/index.ts",
+      "types": "./dist/util/index.d.ts",
+      "import": "./dist/util/index.mjs",
+      "require": "./dist/util/index.js"
     },
     "./package.json": "./package.json"
   },

--- a/packages/toolkit/package.json
+++ b/packages/toolkit/package.json
@@ -19,75 +19,75 @@
   "exports": {
     ".": {
       "@arcanejs/source": "./src/index.ts",
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
-      "require": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "require": "./dist/index.js"
     },
     "./components/base": {
       "@arcanejs/source": "./src/backend/components/base.ts",
+      "types": "./dist/backend/components/base.d.ts",
       "import": "./dist/backend/components/base.mjs",
-      "require": "./dist/backend/components/base.js",
-      "types": "./dist/backend/components/base.d.ts"
+      "require": "./dist/backend/components/base.js"
     },
     "./components/button": {
       "@arcanejs/source": "./src/backend/components/button.ts",
+      "types": "./dist/backend/components/button.d.ts",
       "import": "./dist/backend/components/button.mjs",
-      "require": "./dist/backend/components/button.js",
-      "types": "./dist/backend/components/button.d.ts"
+      "require": "./dist/backend/components/button.js"
     },
     "./components/group": {
       "@arcanejs/source": "./src/backend/components/group.ts",
+      "types": "./dist/backend/components/group.d.ts",
       "import": "./dist/backend/components/group.mjs",
-      "require": "./dist/backend/components/group.js",
-      "types": "./dist/backend/components/group.d.ts"
+      "require": "./dist/backend/components/group.js"
     },
     "./components/label": {
       "@arcanejs/source": "./src/backend/components/label.ts",
+      "types": "./dist/backend/components/label.d.ts",
       "import": "./dist/backend/components/label.mjs",
-      "require": "./dist/backend/components/label.js",
-      "types": "./dist/backend/components/label.d.ts"
+      "require": "./dist/backend/components/label.js"
     },
     "./components/rect": {
       "@arcanejs/source": "./src/backend/components/rect.ts",
+      "types": "./dist/backend/components/rect.d.ts",
       "import": "./dist/backend/components/rect.mjs",
-      "require": "./dist/backend/components/rect.js",
-      "types": "./dist/backend/components/rect.d.ts"
+      "require": "./dist/backend/components/rect.js"
     },
     "./components/slider-button": {
       "@arcanejs/source": "./src/backend/components/slider-button.ts",
+      "types": "./dist/backend/components/slider-button.d.ts",
       "import": "./dist/backend/components/slider-button.mjs",
-      "require": "./dist/backend/components/slider-button.js",
-      "types": "./dist/backend/components/slider-button.d.ts"
+      "require": "./dist/backend/components/slider-button.js"
     },
     "./components/switch": {
       "@arcanejs/source": "./src/backend/components/switch.ts",
+      "types": "./dist/backend/components/switch.d.ts",
       "import": "./dist/backend/components/switch.mjs",
-      "require": "./dist/backend/components/switch.js",
-      "types": "./dist/backend/components/switch.d.ts"
+      "require": "./dist/backend/components/switch.js"
     },
     "./components/tabs": {
       "@arcanejs/source": "./src/backend/components/tabs.ts",
+      "types": "./dist/backend/components/tabs.d.ts",
       "import": "./dist/backend/components/tabs.mjs",
-      "require": "./dist/backend/components/tabs.js",
-      "types": "./dist/backend/components/tabs.d.ts"
+      "require": "./dist/backend/components/tabs.js"
     },
     "./components/text-input": {
       "@arcanejs/source": "./src/backend/components/text-input.ts",
+      "types": "./dist/backend/components/text-input.d.ts",
       "import": "./dist/backend/components/text-input.mjs",
-      "require": "./dist/backend/components/text-input.js",
-      "types": "./dist/backend/components/text-input.d.ts"
+      "require": "./dist/backend/components/text-input.js"
     },
     "./components/timeline": {
       "@arcanejs/source": "./src/backend/components/timeline.ts",
+      "types": "./dist/backend/components/timeline.d.ts",
       "import": "./dist/backend/components/timeline.mjs",
-      "require": "./dist/backend/components/timeline.js",
-      "types": "./dist/backend/components/timeline.d.ts"
+      "require": "./dist/backend/components/timeline.js"
     },
     "./util": {
       "@arcanejs/source": "./src/backend/util/index.ts",
+      "types": "./dist/backend/util/index.d.ts",
       "import": "./dist/backend/util/index.mjs",
-      "require": "./dist/backend/util/index.js",
-      "types": "./dist/backend/util/index.d.ts"
+      "require": "./dist/backend/util/index.js"
     },
     "./package.json": "./package.json"
   },

--- a/packages/toolkit/src/backend/components/button.ts
+++ b/packages/toolkit/src/backend/components/button.ts
@@ -14,6 +14,7 @@ export type InternalProps = {
   icon: string | null;
   mode: ButtonMode;
   error: string | null;
+  onClick?: Events['click'] | null;
 };
 
 export type Props = Partial<InternalProps>;
@@ -23,6 +24,7 @@ const DEFAULT_PROPS: InternalProps = {
   icon: null,
   mode: 'normal',
   error: null,
+  onClick: null,
 };
 
 export class Button extends Base<InternalProps> implements Listenable<Events> {
@@ -30,7 +32,17 @@ export class Button extends Base<InternalProps> implements Listenable<Events> {
   private readonly events = new EventEmitter<Events>();
 
   public constructor(props?: Props) {
-    super(DEFAULT_PROPS, props);
+    super(DEFAULT_PROPS, props, {
+      onPropsUpdated: (oldProps) =>
+        this.events.processPropChanges(
+          {
+            onClick: 'click',
+          },
+          oldProps,
+          this.props,
+        ),
+    });
+    this.triggerInitialPropsUpdate();
   }
 
   addListener = this.events.addListener;

--- a/packages/toolkit/src/backend/components/group.ts
+++ b/packages/toolkit/src/backend/components/group.ts
@@ -24,6 +24,7 @@ export type InternalProps = GroupComponentStyle &
   GroupOptions & {
     title: string | null;
     labels: Label[] | null;
+    onTitleChanged?: Events['title-changed'];
   };
 
 export type Props = Partial<InternalProps>;
@@ -62,7 +63,17 @@ export class Group
   private readonly events = new EventEmitter<Events>();
 
   public constructor(props?: Props) {
-    super(DEFAULT_PROPS, props);
+    super(DEFAULT_PROPS, props, {
+      onPropsUpdated: (oldProps) =>
+        this.events.processPropChanges(
+          {
+            onTitleChanged: 'title-changed',
+          },
+          oldProps,
+          this.props,
+        ),
+    });
+    this.triggerInitialPropsUpdate();
   }
 
   addListener = this.events.addListener;

--- a/packages/toolkit/src/backend/components/slider-button.ts
+++ b/packages/toolkit/src/backend/components/slider-button.ts
@@ -13,6 +13,7 @@ type InternalProps = Pick<
 > & {
   value?: number;
   defaultValue?: number;
+  onChange?: Events['change'];
 };
 
 type RequiredProps = 'value';
@@ -41,9 +42,18 @@ export class SliderButton
 
   public constructor(props?: Props) {
     super(DEFAULT_PROPS, props, {
-      onPropsUpdated: () => this.onPropsUpdated(),
+      onPropsUpdated: (oldProps) => {
+        this.events.processPropChanges(
+          {
+            onChange: 'change',
+          },
+          oldProps,
+          this.props,
+        ),
+          this.onPropsUpdated();
+      },
     });
-    this.onPropsUpdated();
+    this.triggerInitialPropsUpdate();
   }
 
   addListener = this.events.addListener;

--- a/packages/toolkit/src/backend/components/switch.ts
+++ b/packages/toolkit/src/backend/components/switch.ts
@@ -10,6 +10,7 @@ export type Events = {
 type InternalProps = {
   value?: 'on' | 'off';
   defaultValue?: 'on' | 'off';
+  onChange?: Events['change'];
 };
 
 export type Props = Partial<InternalProps>;
@@ -28,9 +29,18 @@ export class Switch extends Base<InternalProps> implements Listenable<Events> {
 
   public constructor(props?: Props) {
     super(DEFAULT_PROPS, props, {
-      onPropsUpdated: () => this.onPropsUpdated(),
+      onPropsUpdated: (oldProps) => {
+        this.events.processPropChanges(
+          {
+            onChange: 'change',
+          },
+          oldProps,
+          this.props,
+        ),
+          this.onPropsUpdated();
+      },
     });
-    this.onPropsUpdated();
+    this.triggerInitialPropsUpdate();
   }
 
   addListener = this.events.addListener;

--- a/packages/toolkit/src/backend/components/text-input.ts
+++ b/packages/toolkit/src/backend/components/text-input.ts
@@ -9,6 +9,7 @@ export type Events = {
 
 type InternalProps = {
   value: string | null;
+  onChange?: Events['change'];
 };
 
 export type Props = Partial<InternalProps>;
@@ -25,7 +26,17 @@ export class TextInput
   private readonly events = new EventEmitter<Events>();
 
   public constructor(props?: Props) {
-    super(DEFAULT_PROPS, props);
+    super(DEFAULT_PROPS, props, {
+      onPropsUpdated: (oldProps) =>
+        this.events.processPropChanges(
+          {
+            onChange: 'change',
+          },
+          oldProps,
+          this.props,
+        ),
+    });
+    this.triggerInitialPropsUpdate();
   }
 
   addListener = this.events.addListener;


### PR DESCRIPTION
To pave the way for allowing for easier creation of custom components, rather than having hard-coded event listener updates in react-toolkit, just expose the listener props as properties in the `@arcanejs/toolkit` components, and have them respond to changes in their props by auto calling addListener or removeListener as needed.