### PR TITLE
Use & test new version of changeset action

### DIFF
--- a/.changeset/eleven-moose-lick.md
+++ b/.changeset/eleven-moose-lick.md
@@ -1,0 +1,5 @@
+---
+'@arcanejs/react-toolkit': patch
+---
+
+Test new publish action

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,7 @@ jobs:
         run: |
           VERSION=$(cat package.json | grep '"packageManager": "pnpm@' | sed 's/.*"pnpm@\([^"]*\)".*/\1/')
           npm install -g pnpm@$VERSION
-      - uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v 4.0.2
+      - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: ~/.pnpm-store
           key: ${{ runner.os }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}

--- a/.github/workflows/release-and-publish.yaml
+++ b/.github/workflows/release-and-publish.yaml
@@ -36,7 +36,7 @@ jobs:
       - run: pnpm build
       - run: cp .npmrc.ci .npmrc
       - name: Run Changeset Workflow
-        uses: s0/changesets-action@19928009614c3d4d2579809551b0df04214b28cf # pinned-vB
+        uses: s0/changesets-action@262aa7c9cf2aece980b2574e10535f4a7c81cc50 # v1.6.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release-and-publish.yaml
+++ b/.github/workflows/release-and-publish.yaml
@@ -28,7 +28,7 @@ jobs:
           VERSION=$(cat package.json | grep '"packageManager": "pnpm@' | sed 's/.*"pnpm@\([^"]*\)".*/\1/')
           npm install -g pnpm@$VERSION
       - name: Cache pnpm modules
-        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v 4.0.2
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: ~/.pnpm-store
           key: ${{ runner.os }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}


### PR DESCRIPTION
See: https://github.com/changesets/action/pull/391

This PR tests the release & publish functionality using with `commitUsingApi` set to true.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Introduced a patch update that tests a new publishing action for the toolkit.
  - Enhanced automation reliability by updating the release workflow to a more stable dependency version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->